### PR TITLE
Feature/distance maps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ add_executable(${PROJECT_NAME}
     src/screens/splashScreen.cpp
     src/screens/levelScreen.cpp
     src/screens/exitScreen.cpp
+    src/screens/ui.cpp
     src/strategy/villagerStrategy.cpp
     src/utils/datastore.cpp
     src/utils/debugStats.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,12 +38,15 @@ add_executable(${PROJECT_NAME}
     src/screens/splashScreen.cpp
     src/screens/levelScreen.cpp
     src/screens/exitScreen.cpp
-    src/utils/datastore.cpp)
+    src/strategy/villagerStrategy.cpp
+    src/utils/datastore.cpp
+    src/utils/debugStats.cpp)
 
 include_directories(src/
                     src/screens
                     src/utils
                     src/character
+                    src/strategy
                     src/demos)
 
 #set(raylib_VERBOSE 1)

--- a/src/character/character.cpp
+++ b/src/character/character.cpp
@@ -1,5 +1,5 @@
 #include "character.h"
-#include <iostream>
+#include "debugStats.h"
 
 void Sprite::draw(float delta)
 {
@@ -28,7 +28,12 @@ void AnimatedSprite::draw(float delta)
     if ( updateAnimation )
     {
         float tmpDelta = delta + this->animationState.frameDelta;
+        if ( tmpDelta > 1.0 )
+        {
+            tmpDelta = this->animationState.frameDelta;
+        }
 
+        /// with too many NPC the program gets stuck in this loop with tmpDelta rediculously high
         while ( tmpDelta > this->animations[this->animationState.activeAnimation].frames[this->animationState.activeFrame].first )
         {
             tmpDelta -= this->animations[this->animationState.activeAnimation].frames[this->animationState.activeFrame].first;
@@ -41,6 +46,12 @@ void AnimatedSprite::draw(float delta)
             if ( nextFrame != this->animationState.activeFrame )
             {
                 this->animationState.activeFrame = nextFrame;
+            }
+            if ( tmpDelta > FRAMESKIP_MAX )
+            {
+                DebugStats::getInstance().addFrameSkip();
+                tmpDelta = this->animationState.frameDelta;
+                break;
             }
         }
         this->animationState.frameDelta = tmpDelta;

--- a/src/character/character.h
+++ b/src/character/character.h
@@ -6,6 +6,14 @@
 #include <vector>
 #include <string>
 
+const int FRAMESKIP_MAX = 10.0;
+
+using DistanceMapType = enum { FIRE_DISTANCE = 0,
+                               PLAYER_DISTANCE = 1,
+                               VILLAGE_DISTANCE = 2,
+                               MAGE_DISTANCE = 3 };
+using DistanceMap = std::vector<std::vector<int>>;
+using MappedDistanceMaps = std::map<int,DistanceMap>;
 /**
  * @brief type for direction
  * @note unused, delete if not used later
@@ -28,7 +36,7 @@ using ActionFunction = bool (*)(Character *);
  * @param character pointer to character
  * @param distanceMap   distances for every coordinate to something ...
  */
-using StateFunction = bool (*)(Character *, std::vector<std::vector<int>>); 
+using StateFunction = bool (*)(Character *, MappedDistanceMaps); 
 /// forward declaration for AnimationTrigger
 class Animation;
 /**
@@ -60,6 +68,15 @@ enum class CharacterState
     CHAR_ATTACK_W = 9,
     CHAR_SPECIAL_1 = 10,
     CHAR_SPECIAL_2 = 11};
+
+/// character status values
+typedef struct CharacterStatusValues
+{
+    /// hitpoints
+    int HP;
+    /// energy points
+    int EP;
+};
 
 /// Animation structure
 typedef struct Animation
@@ -148,9 +165,10 @@ public:
 class Character
 {
 public:
-    Character(std::string name, CharacterState state, Rectangle worldBounds, Rectangle screenBounds, AnimatedSprite *sprite)
+    Character(std::string name, CharacterState state, CharacterStatusValues stats, Rectangle worldBounds, Rectangle screenBounds, AnimatedSprite *sprite)
         : name(name),
         state(state),
+        stats(stats),
         worldBounds(worldBounds),
         screenBounds(screenBounds),
             sprite(sprite) {}
@@ -168,6 +186,8 @@ public:
     std::map<CharacterState, StateFunction> strategy;
     /// pointer to animated sprite
     AnimatedSprite *sprite;
+    /// character stats
+    CharacterStatusValues stats;
 };
 
 #endif // CHARACTER_H

--- a/src/character/character.h
+++ b/src/character/character.h
@@ -70,7 +70,7 @@ enum class CharacterState
     CHAR_SPECIAL_2 = 11};
 
 /// character status values
-typedef struct CharacterStatusValues
+typedef struct WorldObjectStatus
 {
     /// hitpoints
     int HP;
@@ -165,7 +165,7 @@ public:
 class Character
 {
 public:
-    Character(std::string name, CharacterState state, CharacterStatusValues stats, Rectangle worldBounds, Rectangle screenBounds, AnimatedSprite *sprite)
+    Character(std::string name, CharacterState state, WorldObjectStatus stats, Rectangle worldBounds, Rectangle screenBounds, AnimatedSprite *sprite)
         : name(name),
         state(state),
         stats(stats),
@@ -187,7 +187,7 @@ public:
     /// pointer to animated sprite
     AnimatedSprite *sprite;
     /// character stats
-    CharacterStatusValues stats;
+    WorldObjectStatus stats;
 };
 
 #endif // CHARACTER_H

--- a/src/character/characterAnimations.h
+++ b/src/character/characterAnimations.h
@@ -25,11 +25,11 @@ Animation charAnimationWalkS = { -1, {},
         { { 0.3, {80.0,0.0,16.0,16.0} },
         { 0.3, {96.0,0.0,16.0,16.0} }
         }};
-Animation charAnimationWalkW = { -1, {},
+Animation charAnimationWalkE = { -1, {},
         { { 0.3, {16.0,0.0,-16.0,16.0} },
         { 0.3, {32.0,0.0,-16.0,16.0} }
         }};
-Animation charAnimationWalkE = { -1, {}, 
+Animation charAnimationWalkW = { -1, {}, 
         { { 0.3, {16.0,0.0,16.0,16.0} },
         { 0.3, {32.0,0.0,16.0,16.0} }
         }};

--- a/src/demos/lifeDemo.cpp
+++ b/src/demos/lifeDemo.cpp
@@ -4,80 +4,8 @@
 #include "raylib.h"
 #include "types.h"
 #include "animation.h"
+#include "ui.h"
 
-class PlayerState
-{
-public:
-    PlayerState(int HP, int EP) : HP(HP), EP(EP) {}
-    int HP;
-    int EP;
-};
-
-class UI
-{
-public:
-    UI(Vector2 pos, float scale, PlayerState *playerState):
-        pos(pos),
-        scale(scale),
-        playerState(playerState)
-    {
-        this->texture = LoadTexture("images/ui.png");
-        this->lifeSprite = new AnimatedSprite(
-            // texture bounds
-            {0.0,0.0,16.0,16.0},
-            // screen bounds
-            {0.0,0.0,16.0f * scale, 16.0f * scale},
-            this->texture,
-            {{CharacterState::CHAR_IDLE,
-            (Animation){-1, {},
-            {   {0.2, {0.0,0.0,16.0,16.0}},
-                {0.2, {16.0,0.0,16.0,16.0}},
-                {0.2, {32.0,0.0,16.0,16.0}},
-                {0.2, {48.0,0.0,16.0,16.0}},
-                {0.2, {64.0,0.0,16.0,16.0}},
-                {0.2, {80.0,0.0,16.0,16.0}}
-            }}}});
-        this->fireSprite = new AnimatedSprite(
-            // texture bounds
-            {0.0,16.0,16.0,16.0},
-            // screen bounds
-            {100.0,0.0,16.0f * scale, 16.0f * scale},
-            this->texture,
-            {{CharacterState::CHAR_IDLE,
-            (Animation){-1, {},
-            {   {0.2, {0.0,0.0,16.0,16.0}},
-                {0.2, {16.0,0.0,16.0,16.0}},
-                {0.2, {32.0,0.0,16.0,16.0}},
-                {0.2, {48.0,0.0,16.0,16.0}},
-                {0.2, {64.0,0.0,16.0,16.0}},
-                {0.2, {80.0,0.0,16.0,16.0}}
-            }}}});
-    }
-
-    void draw(float delta)
-    {
-        this->lifeSprite->draw(delta);
-        DrawRectangleRec((Rectangle){40,16,static_cast<float>(this->playerState->HP), 20}, {172, 50, 50, 255});
-        DrawRectangleLinesEx((Rectangle){40,16,static_cast<float>(this->playerState->HP), 20}, 2, {75, 22, 22, 255});
-        std::stringstream hpText;
-        hpText << this->playerState->HP;
-        DrawText(hpText.str().c_str(), 42, 2, 30, LIGHTGRAY);
-
-        this->fireSprite->draw(delta);
-        DrawRectangleRec((Rectangle){240,16,static_cast<float>(this->playerState->EP), 20}, {255, 134, 0, 255});
-        DrawRectangleLinesEx((Rectangle){240,16,static_cast<float>(this->playerState->EP), 20}, 2, {186, 47, 0, 255});
-        std::stringstream epText;
-        epText << this->playerState->EP;
-        DrawText(epText.str().c_str(), 242, 2, 30, LIGHTGRAY);
-    }
-private:
-    Vector2 pos;
-    float scale;
-    Texture texture;
-    PlayerState *playerState;
-    AnimatedSprite *lifeSprite;
-    AnimatedSprite *fireSprite;
-};
 
 class LifeGrid
 {
@@ -197,7 +125,7 @@ void showLifeDemo()
     const int screenHeight = 32 * 20;
     const float scaleFactor = 2;
 
-    PlayerState playerState(20,30);
+    WorldObjectStatus playerState = {20,30};
 
     LifeGrid lifeGrid({24,20}, scaleFactor, new TileMap(LoadTexture("images/tileMap.png"), {16.0,16.0}, {4,4}), {3,0}, {3,2});
     lifeGrid.init();

--- a/src/screens/levelScreen.cpp
+++ b/src/screens/levelScreen.cpp
@@ -496,9 +496,6 @@ void LevelScreen::draw(float delta)
     TRACE;
     BeginDrawing();
         ClearBackground(GREEN);
-            DrawRectangleLinesEx(this->player->sprite->screenBounds, 1.0, RED);
-            DrawText("this is the LEVEL", 100,100,30,ORANGE);
-            DrawText("click on the dragon to exit", 100,300,30,ORANGE);
 
         //int numTiles = this->tiles.draw();
         //infoScreen->setNumTiles(numTiles);

--- a/src/screens/levelScreen.cpp
+++ b/src/screens/levelScreen.cpp
@@ -91,7 +91,7 @@ void LevelScreen::loadCharacters()
         npcWorldBounds.x = GetRandomValue(0, this->levelSize.x);
         npcWorldBounds.y = GetRandomValue(0, this->levelSize.y);
         npcScreenBounds = LevelScreen::WorldToScreen(this, npcWorldBounds);
-        npcTextureBounds.y = 0;//GetRandomValue(0,4) * 16;
+        npcTextureBounds.y = GetRandomValue(1,3) * 16;
         CharacterState npcState = stateMap[static_cast<int>(GetRandomValue(0,5))];
         npcState = CharacterState::CHAR_IDLE;
         this->characters.push_back(
@@ -136,7 +136,7 @@ void LevelScreen::loadObjects()
     Rectangle objectScreenBounds{0,0,1,1};
     Rectangle objectTextureBounds{0,0,16,32};
     this->objectTexture = Datastore::getInstance().getTexture("images/assets.png");
-    const int MAX_OBJECTS = 2;
+    const int MAX_OBJECTS = 20;
     std::map<CharacterState, Animation> objectAnimations = 
         {{CharacterState::CHAR_IDLE,
             (Animation){-1, {},
@@ -333,9 +333,17 @@ void LevelScreen::movePlayer(float delta)
     }
 }
 
-bool LevelScreen::checkCollision(Rectangle worldBounds)
+bool LevelScreen::checkCollision(Character *source, Rectangle worldBounds)
 {
-    // TODO
+    /// TODO HELL NO THIS IS SLOW - USE A QUADTREE OR SOMETHING; BUT NOT THIS WAAAAAAAAH
+    /// this is complexity O(n^2) ... there is a solution to do this in worst case O(nlogn)
+    for ( Character *target : this->drawableObjects )
+    {
+        if ( target != source && CheckCollisionRecs(worldBounds, target->worldBounds))
+        {
+            return true;
+        }
+    }
     return false;
 }
 
@@ -369,7 +377,7 @@ void LevelScreen::moveNPCs(float delta)
             Rectangle tempBounds = npc->worldBounds;
             tempBounds.x += deltaPos.x;
             tempBounds.y += deltaPos.y;
-            if ( not this->checkCollision(tempBounds) )
+            if ( not this->checkCollision(npc, tempBounds) )
             {
                 npc->worldBounds = tempBounds;
                 npc->screenBounds = LevelScreen::WorldToScreen(this, tempBounds);

--- a/src/screens/levelScreen.cpp
+++ b/src/screens/levelScreen.cpp
@@ -50,7 +50,7 @@ void LevelScreen::loadCharacters()
 
     Rectangle playerWorldBounds{100,100,64,64};
     Rectangle playerScreenBounds = LevelScreen::WorldToScreen(this, playerWorldBounds);
-    CharacterStatusValues initialPlayerStats = {10,10};
+    WorldObjectStatus initialPlayerStats = {10,10};
     this->player = new Character("player", CharacterState::CHAR_IDLE, initialPlayerStats, playerWorldBounds, playerScreenBounds, new AnimatedSprite(
         {0.0,0.0,32.0,32.0},
         {100.0,100.0,64.0,64.0},
@@ -67,7 +67,7 @@ void LevelScreen::loadCharacters()
     Rectangle npcWorldBounds;
     npcWorldBounds.width = 1;
     npcWorldBounds.height = 1;
-    CharacterStatusValues initialNPCStats = {10,10};
+    WorldObjectStatus initialNPCStats = {10,10};
     Rectangle npcScreenBounds{0,0,16,16};
     Rectangle npcTextureBounds{0,0,16,16};
     this->npcTexture = Datastore::getInstance().getTexture("images/villagers.png");
@@ -132,7 +132,7 @@ void LevelScreen::loadObjects()
     Rectangle objectWorldBounds;
     objectWorldBounds.width = 1;
     objectWorldBounds.height = 2;
-    CharacterStatusValues initialObjectStats = {10,10};
+    WorldObjectStatus initialObjectStats = {10,10};
     Rectangle objectScreenBounds{0,0,1,1};
     Rectangle objectTextureBounds{0,0,16,32};
     this->objectTexture = Datastore::getInstance().getTexture("images/assets.png");
@@ -215,6 +215,11 @@ void LevelScreen::loadTiles()
     this->tiles.updateCamera(this->camera);
 }
 
+void LevelScreen::loadUI()
+{
+    this->ui = new UI({0,0}, 2.0, &this->player->stats);
+}
+
 void LevelScreen::initialize()
 {
     TRACE;
@@ -225,13 +230,15 @@ void LevelScreen::initialize()
     this->camera.zoom = 1.0;
     //SetTargetFPS(-1);
 
-    this->infoScreen = new InfoScreen({200,10});
+    this->infoScreen = new InfoScreen({400,10});
     
     loadTiles();
 
     loadObjects();
 
     loadCharacters();
+
+    loadUI();
 
     for (int i = 0; i < 4; ++i )
     {
@@ -522,7 +529,7 @@ void LevelScreen::draw(float delta)
             }
         }
 
-        player->sprite->draw(delta);
+        this->ui->draw(delta);
 
         this->infoScreen->draw(delta);
     EndDrawing();

--- a/src/screens/levelScreen.cpp
+++ b/src/screens/levelScreen.cpp
@@ -19,13 +19,11 @@ void InfoScreen::draw(float delta)
         sumDelta -= 1.0;
         frameCnt = 0;
     }
-    BeginDrawing();
-        /// TODO make this stuff dynamic, liek the demo-list
-        DrawText(fpsText.c_str(), this->origin.x + 0, this->origin.y + 0,30,ORANGE);
-        DrawText(scaleText.c_str(), this->origin.x + 150, this->origin.y + 0,30,ORANGE);
-        DrawText(this->tileText.c_str(), this->origin.x + 0, this->origin.y + 30, 30, BLUE);
-        DrawText(this->distanceMapText.c_str(), this->origin.x + 0, this->origin.y + 60, 30, WHITE);
-    EndDrawing();
+    /// TODO make this stuff dynamic, liek the demo-list
+    DrawText(fpsText.c_str(), this->origin.x + 0, this->origin.y + 0,30,ORANGE);
+    DrawText(scaleText.c_str(), this->origin.x + 150, this->origin.y + 0,30,ORANGE);
+    DrawText(this->tileText.c_str(), this->origin.x + 0, this->origin.y + 30, 30, BLUE);
+    DrawText(this->distanceMapText.c_str(), this->origin.x + 0, this->origin.y + 60, 30, WHITE);
 }
 void InfoScreen::setActiveDistanceMap(DistanceMapType selectedDebugDistanceMap){
     this->selectedDebugDistanceMap = selectedDebugDistanceMap;
@@ -413,10 +411,19 @@ void LevelScreen::update(float delta)
         DebugStats::getInstance().printStats();
     }
     // cycle through distance maps - NOTE: write the active distance map somewhere
+    static bool isKeyQPressed = true;
     if ( IsKeyDown(KEY_Q) )
     {
-        selectedDebugDistanceMap = static_cast<DistanceMapType>((static_cast<int>(selectedDebugDistanceMap) + 1 ) % this->distanceMaps.size());
-        infoScreen->setActiveDistanceMap(selectedDebugDistanceMap);
+        if ( !isKeyQPressed )
+        {
+            selectedDebugDistanceMap = static_cast<DistanceMapType>((static_cast<int>(selectedDebugDistanceMap) + 1 ) % this->distanceMaps.size());
+            infoScreen->setActiveDistanceMap(selectedDebugDistanceMap);   
+        }
+        isKeyQPressed = true;
+    }
+    else
+    {
+        isKeyQPressed = false;
     }
     float zoomDelta = GetMouseWheelMove();
     bool needsUpdate = false;
@@ -458,7 +465,6 @@ void LevelScreen::update(float delta)
     /// TODO z-sort characters and objects !!!
 
     this->draw(delta);
-    this->infoScreen->draw(delta);
 }
 void LevelScreen::sortDrawableObjects()
 {
@@ -510,6 +516,7 @@ void LevelScreen::draw(float delta)
 
         player->sprite->draw(delta);
 
+        this->infoScreen->draw(delta);
     EndDrawing();
 
 }

--- a/src/screens/levelScreen.h
+++ b/src/screens/levelScreen.h
@@ -125,12 +125,14 @@ private:
     void moveNPCs(float delta);
     void updateNPCs(float delta);
     bool checkCollision(Rectangle worldBounds);
-    void updateDistanceMaps(Vector2 worldTargetPos);
+    void updateDistanceMap(DistanceMapType selectedDistanceMap, Vector2 worldTargetPos);
+    void sortDrawableObjects();
     Camera2D camera;
     Vector2 levelSize;
 
     std::vector<Character*> characters;
-    std::vector<Character> objects;
+    std::vector<Character*> objects;
+    std::vector<Character*> drawableObjects;
     Character *player;
 
     Texture2D objectTexture, npcTexture;

--- a/src/screens/levelScreen.h
+++ b/src/screens/levelScreen.h
@@ -124,7 +124,7 @@ private:
     void movePlayer(float delta);
     void moveNPCs(float delta);
     void updateNPCs(float delta);
-    bool checkCollision(Rectangle worldBounds);
+    bool checkCollision(Character *source, Rectangle worldBounds);
     void updateDistanceMap(DistanceMapType selectedDistanceMap, Vector2 worldTargetPos);
     void sortDrawableObjects();
     Camera2D camera;

--- a/src/screens/levelScreen.h
+++ b/src/screens/levelScreen.h
@@ -1,6 +1,7 @@
 #ifndef LEVEL_SCREEN_H
 #define LEVEL_SCREEN_H
 #include "game.h"
+#include "ui.h"
 
 /// info screen
 class InfoScreen
@@ -121,6 +122,7 @@ private:
     void loadCharacters();
     void loadObjects();
     void loadTiles();
+    void loadUI();
     void movePlayer(float delta);
     void moveNPCs(float delta);
     void updateNPCs(float delta);
@@ -134,6 +136,8 @@ private:
     std::vector<Character*> objects;
     std::vector<Character*> drawableObjects;
     Character *player;
+
+    UI *ui;
 
     Texture2D objectTexture, npcTexture;
 

--- a/src/screens/levelScreen.h
+++ b/src/screens/levelScreen.h
@@ -10,6 +10,7 @@ public:
     void draw(float delta);
     std::string scaleText;
     void setNumTiles(int numTiles);
+    void setActiveDistanceMap(DistanceMapType selectedDebugDistanceMap);
 private:
     Vector2 origin;
     float sumDelta;
@@ -17,13 +18,15 @@ private:
     std::string fpsText;
     std::string tileText;
     int numTiles;
+    std::string distanceMapText;
+    DistanceMapType selectedDebugDistanceMap;
 };
 
 /// level screen
 class LevelScreen : public GameScreen, public GameState
 {
 public:
-    LevelScreen(Game *game) : GameScreen(game), isDone(false), scale(1), offset({0,0})
+    LevelScreen(Game *game) : GameScreen(game), isDone(false), scale(1), offset({0,0}), selectedDebugDistanceMap(static_cast<DistanceMapType>(0))
     //, tileSize({16,16})
      {}
     virtual void initialize() override;
@@ -104,7 +107,6 @@ public:
     }
 private:
     /// TODO total mess below, CLEAN UP @Radulf
-    AnimatedSprite *dragonSprite;
     Vector2 charSpeed;
     float charSpeedMax;
     float charAcc;
@@ -133,8 +135,11 @@ private:
 
     Texture2D objectTexture, npcTexture;
 
-    /// TODO first prototype of distance map. split into multiple maps (with better types) later
-    std::vector<std::vector<int>> distanceMap;
+    /// distance maps - mapped per distance-type
+    MappedDistanceMaps distanceMaps;
+    
+    DistanceMapType selectedDebugDistanceMap;
+
 };
 
 #endif // LEVEL_SCREEN_H

--- a/src/screens/ui.cpp
+++ b/src/screens/ui.cpp
@@ -1,0 +1,20 @@
+#include "ui.h"
+#include <sstream>
+void UI::draw(float delta)
+{
+    /// TODO make that a texture
+    DrawRectangleRec({pos.x, pos.y, 400,40}, {55,55,30,125});
+    this->lifeSprite->draw(delta);
+    DrawRectangleRec((Rectangle){40,16,static_cast<float>(this->playerState->HP), 20}, {172, 50, 50, 255});
+    DrawRectangleLinesEx((Rectangle){40,16,static_cast<float>(this->playerState->HP), 20}, 2, {75, 22, 22, 255});
+    std::stringstream hpText;
+    hpText << this->playerState->HP;
+    DrawText(hpText.str().c_str(), 42, 2, 30, LIGHTGRAY);
+
+    this->fireSprite->draw(delta);
+    DrawRectangleRec((Rectangle){240,16,static_cast<float>(this->playerState->EP), 20}, {255, 134, 0, 255});
+    DrawRectangleLinesEx((Rectangle){240,16,static_cast<float>(this->playerState->EP), 20}, 2, {186, 47, 0, 255});
+    std::stringstream epText;
+    epText << this->playerState->EP;
+    DrawText(epText.str().c_str(), 242, 2, 30, LIGHTGRAY);
+}

--- a/src/screens/ui.h
+++ b/src/screens/ui.h
@@ -1,0 +1,56 @@
+#ifndef UI_H
+#define UI_H
+#include "character.h"
+
+class UI
+{
+public:
+    UI(Vector2 pos, float scale, WorldObjectStatus *playerState):
+        pos(pos),
+        scale(scale),
+        playerState(playerState)
+    {
+        this->texture = LoadTexture("images/ui.png");
+        this->lifeSprite = new AnimatedSprite(
+            // texture bounds
+            {0.0,0.0,16.0,16.0},
+            // screen bounds
+            {0.0,0.0,16.0f * scale, 16.0f * scale},
+            this->texture,
+            {{CharacterState::CHAR_IDLE,
+            (Animation){-1, {},
+            {   {0.2, {0.0,0.0,16.0,16.0}},
+                {0.2, {16.0,0.0,16.0,16.0}},
+                {0.2, {32.0,0.0,16.0,16.0}},
+                {0.2, {48.0,0.0,16.0,16.0}},
+                {0.2, {64.0,0.0,16.0,16.0}},
+                {0.2, {80.0,0.0,16.0,16.0}}
+            }}}});
+        this->fireSprite = new AnimatedSprite(
+            // texture bounds
+            {0.0,16.0,16.0,16.0},
+            // screen bounds
+            {100.0,0.0,16.0f * scale, 16.0f * scale},
+            this->texture,
+            {{CharacterState::CHAR_IDLE,
+            (Animation){-1, {},
+            {   {0.2, {0.0,0.0,16.0,16.0}},
+                {0.2, {16.0,0.0,16.0,16.0}},
+                {0.2, {32.0,0.0,16.0,16.0}},
+                {0.2, {48.0,0.0,16.0,16.0}},
+                {0.2, {64.0,0.0,16.0,16.0}},
+                {0.2, {80.0,0.0,16.0,16.0}}
+            }}}});
+    }
+
+    void draw(float delta);
+private:
+    Vector2 pos;
+    float scale;
+    Texture texture;
+    WorldObjectStatus *playerState;
+    AnimatedSprite *lifeSprite;
+    AnimatedSprite *fireSprite;
+};
+
+#endif // UI_H

--- a/src/screens/ui.h
+++ b/src/screens/ui.h
@@ -1,6 +1,7 @@
 #ifndef UI_H
 #define UI_H
 #include "character.h"
+#include "datastore.h"
 
 class UI
 {
@@ -10,7 +11,7 @@ public:
         scale(scale),
         playerState(playerState)
     {
-        this->texture = LoadTexture("images/ui.png");
+        this->texture = Datastore::getInstance().getTexture("images/ui.png");
         this->lifeSprite = new AnimatedSprite(
             // texture bounds
             {0.0,0.0,16.0,16.0},

--- a/src/strategy/villagerStrategy.cpp
+++ b/src/strategy/villagerStrategy.cpp
@@ -1,0 +1,95 @@
+#include "villagerStrategy.h"
+
+namespace strategy
+{
+bool getNextState(int &x, int &y, CharacterState &dir, DistanceMap distanceMap)
+{
+    const int maxX = distanceMap.size()-1;
+    const int maxY = distanceMap[0].size()-1;
+    x = (x < 0 ) ? 0 : x > maxX ? maxX : x;
+    y = (y < 0 ) ? 0 : y > maxY ? maxY : y;
+    int dist = distanceMap[x][y];
+    bool update = false;
+    // left
+    if ( x > 0 && distanceMap[x-1][y] < dist )
+    {
+        dist = distanceMap[x-1][y];
+        dir = CharacterState::CHAR_WALK_W;
+        TraceLog(LOG_DEBUG, "%s, left dist: %d", __func__, dist);
+        update = true;
+    } // right
+    if ( x < maxX && distanceMap[x+1][y] < dist )
+    {
+        dist = distanceMap[x+1][y];
+        dir = CharacterState::CHAR_WALK_E;
+        TraceLog(LOG_DEBUG, "%s, right dist: %d", __func__, dist);
+        update = true;
+    } // up
+    if ( y > 0 && distanceMap[x][y-1] < dist )
+    {
+        dist = distanceMap[x][y-1];
+        dir = CharacterState::CHAR_WALK_N;
+        TraceLog(LOG_DEBUG, "%s, up dist: %d", __func__, dist);
+        update = true;
+    } // down
+    if ( y < maxY && distanceMap[x][y+1] < dist )
+    {
+        dist = distanceMap[x][y+1];
+        dir = CharacterState::CHAR_WALK_S;
+        TraceLog(LOG_DEBUG, "%s, down dist: %d", __func__, dist);
+        update = true;
+    }
+    if ( !update )
+    {
+        TraceLog(LOG_DEBUG, "%s did not update position - distance at %d, {%d, %d, %d, %d}",
+            __func__, dist,
+            distanceMap[x][y-1], distanceMap[x+1][y],
+            distanceMap[x][y+1], distanceMap[x-1][y]);
+    }
+    return true;
+}
+
+bool idleCharacter(Character *character, MappedDistanceMaps distanceMaps)
+{
+    if ( nullptr == character )
+    {
+        return false;
+    }
+    CharacterState newState = CharacterState::CHAR_IDLE;
+    int x = static_cast<int>(character->worldBounds.x);
+    int y = static_cast<int>(character->worldBounds.y);
+    if ( distanceMaps.count(0) )
+    {
+        getNextState(x, y, newState, distanceMaps[0]);//DistanceMapType::PLAYER_DISTANCE]);
+    }
+    TraceLog(LOG_DEBUG,"%s (%s) state %d -> %d", __func__, character->name,
+     static_cast<int>(character->state), static_cast<int>(newState));
+    if ( newState != CharacterState::CHAR_IDLE )
+    {
+        character->state = newState;
+        character->sprite->animationState.activeAnimation = newState;
+    }
+    return true;
+}
+
+bool moveCharacter(Character *character, MappedDistanceMaps distanceMaps)
+{
+    if ( nullptr == character )
+    {
+        return false;
+    }
+    CharacterState newState = CharacterState::CHAR_IDLE;
+    int x = static_cast<int>(character->worldBounds.x);
+    int y = static_cast<int>(character->worldBounds.y);
+    if ( distanceMaps.count(0) )
+    {
+        getNextState(x, y, newState, distanceMaps[0]);//DistanceMapType::PLAYER_DISTANCE]);
+    }
+    TraceLog(LOG_DEBUG,"%s (%s) state %d -> %d", __func__, character->name,
+     static_cast<int>(character->state), static_cast<int>(newState));
+    character->state = newState;
+    character->sprite->animationState.activeAnimation = newState;
+    return true;
+}
+
+} // namespace strategy

--- a/src/strategy/villagerStrategy.h
+++ b/src/strategy/villagerStrategy.h
@@ -1,0 +1,16 @@
+#ifndef VILLAGER_STRATEGY_H
+#define VILLAGER_STRATEGY_H
+#include "character.h"
+#include <vector>
+#include <map>
+namespace strategy
+{
+bool getNextState(int &x, int &y, CharacterState &dir, DistanceMap distanceMap);
+
+bool idleCharacter(Character *character, MappedDistanceMaps distanceMaps);
+
+bool moveCharacter(Character *character, MappedDistanceMaps distanceMaps);
+
+
+} // end namespace strategy
+#endif // VILLAGER_STRATEGY_H

--- a/src/utils/debugStats.cpp
+++ b/src/utils/debugStats.cpp
@@ -1,0 +1,10 @@
+#include "debugStats.h"
+#include <iostream>
+
+void DebugStats::printStats()
+{
+    std::cerr
+        << "Debug Stats: "
+        << "frameskips: " << this->frameSkips
+    << std::endl;
+}

--- a/src/utils/debugStats.h
+++ b/src/utils/debugStats.h
@@ -1,0 +1,22 @@
+#ifndef DEBUG_STATS_H
+#define DEBUG_STATS_H
+class DebugStats
+{
+public:
+    /// singleton function
+    static DebugStats &getInstance()
+    {
+        static DebugStats singleton;
+        return singleton;
+    }
+    void addFrameSkip()
+    {
+        ++frameSkips;
+    }
+    void printStats();
+private:
+    DebugStats() : frameSkips(0) {}
+    DebugStats(DebugStats const&);
+    int frameSkips;
+};
+#endif // DEBUG_STATS_H


### PR DESCRIPTION
multiple distance maps:
- 4 maps, PLAYER, FIRE, VILLAGE, MAGE
- for debugging the "numbers-overlay" has different colors for the 4 maps
- mouse-click will create a map that computes the manhattan-distance to the in-world mouse-click position
- with the key "q" the maps can be cycled for manipulation with mouse-click
- characters can react on whichever distance-map they want

simple collision detection:
- O(n^2). not good, ... works fast enough for now, so ...

fixed sprite animation order (no moon-walk any more)

added UI from the life-demo
- connected to players stats (HP/EP)